### PR TITLE
[ENG-8577] add eas/checkout to workflows

### DIFF
--- a/.eas/build/demo.yml
+++ b/.eas/build/demo.yml
@@ -1,6 +1,7 @@
 build:
   name: Demo
   steps:
+    - eas/checkout
     - run:
         name: List assets
         working_directory: assets

--- a/.eas/build/test.yml
+++ b/.eas/build/test.yml
@@ -1,6 +1,7 @@
 build:
   name: Run tests
   steps:
+    - eas/checkout
     - run:
         name: Install dependencies
         command: npm install

--- a/.eas/build/upload.yml
+++ b/.eas/build/upload.yml
@@ -1,6 +1,7 @@
 build:
   name: Upload artifacts
   steps:
+    - eas/checkout
     - eas/upload_artifact:
         name: Upload application archive
         inputs:


### PR DESCRIPTION
Follow-up to https://github.com/expo/eas-build/pull/224
The PR updates workflows that use project files so they have `eas/checkout` as the first step.