### PR TITLE
example of custom ts functions

### DIFF
--- a/.eas/build/js-functions.yml
+++ b/.eas/build/js-functions.yml
@@ -1,0 +1,24 @@
+build:
+  name: JS Functions Demo
+  steps:
+    - say_hi_from_js:
+        inputs:
+          name: Dominik
+    - custom_run_gradle
+
+functions:
+  say_hi:
+    name: Hi!
+    inputs:
+      - name
+    command: echo "Hi, ${ inputs.name }!"
+  say_hi_from_js:
+    name: Hi from JS
+    inputs:
+      - name
+    path: ./js-functions/say_hi.js
+  custom_run_gradle:
+    name: Run Gradle
+    path: ./js-functions/run_gradle.ts
+    # or mybe we should point directlly to compiled js
+    # path: ./js-functions/dist/run_gradle.js

--- a/.eas/build/js-functions/.gitignore
+++ b/.eas/build/js-functions/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.eas/build/js-functions/package-lock.json
+++ b/.eas/build/js-functions/package-lock.json
@@ -1,0 +1,137 @@
+{
+  "name": "js-functions",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "js-functions",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@expo/spawn-async": "^1.7.2"
+      }
+    },
+    "node_modules/@expo/spawn-async": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@expo/spawn-async/-/spawn-async-1.7.2.tgz",
+      "integrity": "sha512-QdWi16+CHB9JYP7gma19OVVg0BFkvU8zNj9GjWorYI8Iv8FUxjOCcYRuAmX4s/h91e4e7BPsskc8cSrZYho9Ew==",
+      "dependencies": {
+        "cross-spawn": "^7.0.3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    }
+  },
+  "dependencies": {
+    "@expo/spawn-async": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@expo/spawn-async/-/spawn-async-1.7.2.tgz",
+      "integrity": "sha512-QdWi16+CHB9JYP7gma19OVVg0BFkvU8zNj9GjWorYI8Iv8FUxjOCcYRuAmX4s/h91e4e7BPsskc8cSrZYho9Ew==",
+      "requires": {
+        "cross-spawn": "^7.0.3"
+      }
+    },
+    "cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "requires": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      }
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+    },
+    "path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
+    },
+    "shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "requires": {
+        "shebang-regex": "^3.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
+    },
+    "which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    }
+  }
+}

--- a/.eas/build/js-functions/package.json
+++ b/.eas/build/js-functions/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "js-functions",
+  "version": "1.0.0",
+  "description": "",
+  "main": "run_gradle.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@expo/spawn-async": "^1.7.2"
+  }
+}

--- a/.eas/build/js-functions/run_gradle.ts
+++ b/.eas/build/js-functions/run_gradle.ts
@@ -1,0 +1,6 @@
+import { EasFunctionCtx } from "@expo/eas-steps"
+import spawnAsync from '@expo/spawn-async'
+
+export default function(ctx: EasFunctionCtx, inputs: { name: string }) {
+  await spawnAsync('./gradlew')
+}

--- a/.eas/build/js-functions/say_hi.ts
+++ b/.eas/build/js-functions/say_hi.ts
@@ -1,0 +1,7 @@
+import { EasFunctionCtx } from "@expo/eas-steps"
+// or maybe separate package
+// import { EasFunctionCtx } from "@expo/eas-custom-build" or sth like that
+
+export default function(ctx: EasFunctionCtx, inputs: { name: string }) {
+  console.log(input)
+}

--- a/eas.json
+++ b/eas.json
@@ -59,6 +59,12 @@
       "android": {
         "config": "simple-android-build.yml"
       }
+    },
+    "js": {
+      "distribution": "internal",
+      "android": {
+        "config": "js-functions.yml"
+      }
     }
   }
 }


### PR DESCRIPTION
Example of how config could look for custom js functions


### How implementation in @expo/steps would work:
 - download/checkout the repository in a temporary location (it will be copied to working dir when user calls checkout action)
 - for each function defined as a path
   - Run npm install in the first parent directory with package.json (maybe support other package managers in the future). If more than one function is in the same directory run only once. To avoid confusion we could enforce that the closest package.json has to be inside the .eas directory.
   - Run "npm run build" (the same rules as above) 
 - When execution is reaching the custom function call it. I would expect the code in build-tools to look sth like this
   `spawnAsync("node", [pathToSomeWrapperScript, pathToRunGraldle, serializedFunctionArguments])`
   
### How users could take existing config and modify it:
- Run `npx create-eas-build-step` (or sth like that) that will generate step inside `.eas` directory.
- Go to build-tools package and copy the entire file with our implementation and paste it to ts file in generated code in your project
- User would need to manually add all the dependencies that the plugin is using inside their packae.json


### Some open questions:
- Do we want to allow more than one function in the npm package or should we force the user to create a separate project for each custom step
- Do we want to support both js and ts (and if yes do we want to support both esm and commonjs) or maybe just enforce specific project structure that we are generating and allow only typescript?

   