### PR TITLE
[custom-builds-example] [ENG-11196] Add Slacking example

### DIFF
--- a/.eas/build/send-slack-message.yml
+++ b/.eas/build/send-slack-message.yml
@@ -1,5 +1,5 @@
 build:
-  name: Demo
+  name: Slack your team when build completes
   steps:
     - eas/checkout
 

--- a/.eas/build/send-slack-message.yml
+++ b/.eas/build/send-slack-message.yml
@@ -22,7 +22,7 @@ build:
           slack_hook_url: ${ eas.env.ANOTHER_SLACK_HOOK_URL }
 
     - eas/send_slack_message:
-        if: ${ failed() }
+        if: ${ failure() }
         name: Send Slack message when the build fails
         inputs:
           message: 'This is a test message when build fails'

--- a/.eas/build/send-slack-message.yml
+++ b/.eas/build/send-slack-message.yml
@@ -18,7 +18,7 @@ build:
     - eas/send_slack_message:
         name: Send Slack message to a webhook URL from specified secret
         inputs:
-          message: 'This is a test message to default URL from SLACK_HOOK_URL secret'
+          message: 'This is a test message to an URL from specified secret'
           slack_hook_url: ${ eas.env.ANOTHER_SLACK_HOOK_URL }
 
     - eas/send_slack_message:

--- a/.eas/build/send-slack-message.yml
+++ b/.eas/build/send-slack-message.yml
@@ -18,7 +18,7 @@ build:
     - eas/send_slack_message:
         name: Send Slack message to a webhook URL from specified secret
         inputs:
-          message: 'This is a test message to an URL from specified secret'
+          message: 'This is a test message to a URL from specified secret'
           slack_hook_url: ${ eas.env.ANOTHER_SLACK_HOOK_URL }
 
     - eas/send_slack_message:

--- a/.eas/build/send-slack-message.yml
+++ b/.eas/build/send-slack-message.yml
@@ -20,3 +20,15 @@ build:
         inputs:
           message: 'This is a test message to default URL from SLACK_HOOK_URL secret'
           slack_hook_url: ${ eas.env.ANOTHER_SLACK_HOOK_URL }
+
+    - eas/send_slack_message:
+        if: ${ failed() }
+        name: Send Slack message when the build fails
+        inputs:
+          message: 'This is a test message when build fails'
+
+    - eas/send_slack_message:
+        if: ${ success() }
+        name: Send Slack message when the build succeeds
+        inputs:
+          message: 'This is a test message when build succeeds'

--- a/.eas/build/send-slack-message.yml
+++ b/.eas/build/send-slack-message.yml
@@ -2,7 +2,7 @@ build:
   name: Demo
   steps:
     - eas/checkout
-    -
+
     - eas/send_slack_message:
         name: Send Slack message to a given webhook URL
         inputs:

--- a/.eas/build/send-slack-message.yml
+++ b/.eas/build/send-slack-message.yml
@@ -1,0 +1,21 @@
+build:
+  name: Demo
+  steps:
+    - eas/checkout
+    -
+    - eas/send_slack_message:
+        name: Send Slack message to a given webhook URL
+        inputs:
+          message: 'This is a test message to plain input URL'
+          slack_hook_url: 'https://hooks.slack.com/services/[rest_of_hook_url]'
+
+    - eas/send_slack_message:
+        name: Send Slack message to a default webhook URL from SLACK_HOOK_URL secret
+        inputs:
+          message: 'This is a test message to default URL from SLACK_HOOK_URL secret'
+
+    - eas/send_slack_message:
+        name: Send Slack message to a webhook URL from specified secret
+        inputs:
+          message: 'This is a test message to default URL from SLACK_HOOK_URL secret'
+          slack_hook_url: ${ eas.env.ANOTHER_SLACK_HOOK_URL }

--- a/.eas/build/send-slack-message.yml
+++ b/.eas/build/send-slack-message.yml
@@ -1,7 +1,8 @@
 build:
   name: Slack your team when build completes
   steps:
-    - eas/checkout
+    # For the purpose of the example-test we don't need to do the actual build.
+    # - eas/build
 
     - eas/send_slack_message:
         name: Send Slack message to a given webhook URL

--- a/eas.json
+++ b/eas.json
@@ -73,6 +73,10 @@
       "ios": {
         "config": "remote-version-management-build-ios.yml"
       }
+    },
+    "sendSlackMessage": {
+      "withoutCredentials": true,
+      "config": "send-slack-message.yml"
     }
   }
 }


### PR DESCRIPTION
Added an example workflow using the `eas/send_slack_message` function to send messages over Slack

See: https://linear.app/expo/issue/ENG-11196/create-custom-build-example-slacking-team-members

### Config
![Screenshot 2024-02-09 at 16 26 09](https://github.com/expo/eas-custom-builds-example/assets/2974455/6b8381f4-085d-41da-afd5-15ba47b74a92)

### Build
![Screenshot 2024-02-09 at 16 25 45](https://github.com/expo/eas-custom-builds-example/assets/2974455/4b505156-bf1f-40db-b6bb-3f9faf1421ba)

### Messages
<img width="556" alt="Screenshot 2024-02-09 at 16 25 37" src="https://github.com/expo/eas-custom-builds-example/assets/2974455/8e3dfd17-deff-4ab8-9d6c-2fd0811f864c">

