### PR TITLE
[eas-custom-builds-example] [ENG-11196] Add block kit example

### DIFF
--- a/.eas/build/send-slack-message.yml
+++ b/.eas/build/send-slack-message.yml
@@ -61,3 +61,59 @@ build:
         inputs:
           message: |
             This is a test message when build succeeds
+
+    - eas/send_slack_message:
+        if: ${ always() }
+        name: Send Slack message with Slack Block Kit layout
+        inputs:
+          payload: {
+            "blocks": [{
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "Hello, Sir Developer\n\n *Your build has finished!*"
+                }
+              },
+              {
+                "type": "divider"
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "*${ eas.env.EAS_BUILD_ID }*\n*Status:* `${ steps.run_gradle.status_text }`\n*Link:* `${ eas.job.expoBuildUrl }`"
+                },
+                "accessory": {
+                  "type": "image",
+                  "image_url": "https://static.expo.dev/static/brand/square-512x512.png",
+                  "alt_text": "alt text for image"
+                }
+              },
+              {
+                "type": "divider"
+              },
+              {
+                "type": "actions",
+                "elements": [
+                  {
+                    "type": "button",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "Do a thing :rocket:",
+                      "emoji": true
+                    },
+                    "value": "a_thing"
+                  },
+                  {
+                    "type": "button",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "Do another thing :x:",
+                      "emoji": true
+                    },
+                    "value": "another_thing"
+                  }
+                ]
+              }
+            ]
+          }

--- a/.eas/build/send-slack-message.yml
+++ b/.eas/build/send-slack-message.yml
@@ -66,54 +66,39 @@ build:
         if: ${ always() }
         name: Send Slack message with Slack Block Kit layout
         inputs:
-          payload: {
-            "blocks": [{
-                "type": "section",
-                "text": {
-                  "type": "mrkdwn",
-                  "text": "Hello, Sir Developer\n\n *Your build has finished!*"
-                }
-              },
-              {
-                "type": "divider"
-              },
-              {
-                "type": "section",
-                "text": {
-                  "type": "mrkdwn",
-                  "text": "*${ eas.env.EAS_BUILD_ID }*\n*Status:* `${ steps.run_gradle.status_text }`\n*Link:* `${ eas.job.expoBuildUrl }`"
-                },
-                "accessory": {
-                  "type": "image",
-                  "image_url": "https://static.expo.dev/static/brand/square-512x512.png",
-                  "alt_text": "alt text for image"
-                }
-              },
-              {
-                "type": "divider"
-              },
-              {
-                "type": "actions",
-                "elements": [
-                  {
-                    "type": "button",
-                    "text": {
-                      "type": "plain_text",
-                      "text": "Do a thing :rocket:",
-                      "emoji": true
-                    },
-                    "value": "a_thing"
-                  },
-                  {
-                    "type": "button",
-                    "text": {
-                      "type": "plain_text",
-                      "text": "Do another thing :x:",
-                      "emoji": true
-                    },
-                    "value": "another_thing"
-                  }
-                ]
-              }
-            ]
-          }
+          payload:
+            blocks:
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: |-
+                    Hello, Sir Developer
+                    
+                     *Your build has finished!*
+              - type: divider
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: |-
+                    *${ eas.env.EAS_BUILD_ID }*
+                    *Status:* `${ steps.run_gradle.status_text }`
+                    *Link:* `${ eas.job.expoBuildUrl }`
+                accessory:
+                  type: image
+                  image_url: https://static.expo.dev/static/brand/square-512x512.png
+                  alt_text: alt text for image
+              - type: divider
+              - type: actions
+                elements:
+                  - type: button
+                    text:
+                      type: plain_text
+                      text: 'Do a thing :rocket:'
+                      emoji: true
+                    value: a_thing
+                  - type: button
+                    text:
+                      type: plain_text
+                      text: 'Do another thing :x:'
+                      emoji: true
+                    value: another_thing

--- a/eas.json
+++ b/eas.json
@@ -66,7 +66,8 @@
     },
     "send-slack-message": {
       "withoutCredentials": true,
-      "config": "send-slack-message.yml"
+      "config": "send-slack-message.yml",
+      "image": "latest"
     },
     "build-and-maestro-test": {
       "withoutCredentials": true,

--- a/eas.json
+++ b/eas.json
@@ -66,8 +66,7 @@
     },
     "send-slack-message": {
       "withoutCredentials": true,
-      "config": "send-slack-message.yml",
-      "image": "latest"
+      "config": "send-slack-message.yml"
     },
     "build-and-maestro-test": {
       "withoutCredentials": true,


### PR DESCRIPTION
Added another example of using the eas/send_slack_message function for sending the Slack message using the Block Kit layout for richer messaging

See: https://linear.app/expo/issue/ENG-11196/create-custom-build-example-slacking-team-members

Depends on: https://github.com/expo/eas-build/pull/351