### PR TITLE
Add id field to Apple Team ID resolution step

### DIFF
--- a/.eas/build/ios-build-with-credentials.yml
+++ b/.eas/build/ios-build-with-credentials.yml
@@ -22,8 +22,7 @@ build:
     - eas/get_credentials_for_build_triggered_by_github_integration
 
     - eas/resolve_apple_team_id_from_credentials:
-        inputs:
-          id: resolve_apple_team_id_from_credentials
+        id: resolve_apple_team_id_from_credentials
 
     - eas/prebuild:
         inputs:


### PR DESCRIPTION
This didn't work for me in a build. After updating it to set id, it was all good.

Before:
<img width="1268" alt="Screenshot 2024-03-03 at 5 15 26 PM" src="https://github.com/expo/eas-custom-builds-example/assets/3399180/25262a15-e3f7-478e-8316-85e428bf7281">

After:
<img width="1291" alt="Screenshot 2024-03-03 at 5 16 02 PM" src="https://github.com/expo/eas-custom-builds-example/assets/3399180/0ef830e4-a472-4880-8afc-93adf5015c9b">
